### PR TITLE
Split login and register into separate pages

### DIFF
--- a/packages/e2e-tests/tests/001-auth.spec.js
+++ b/packages/e2e-tests/tests/001-auth.spec.js
@@ -66,7 +66,7 @@ test.describe.serial('User Authentication', () => {
     await login(page, testUser, testPassword);
     await logout(page);
     // After logout, should see the login form
-    await expect(page.locator('section:has-text("Login")')).toBeVisible();
+    await expect(page.locator('section:has-text("Sign In")')).toBeVisible();
   });
 
   test('should maintain session after page reload', async ({ page }) => {
@@ -117,7 +117,7 @@ test.describe.serial('User Authentication', () => {
     // Perform logout and wait for navigation
     await logout(page);
     // After logout, should see the login form
-    await page.waitForSelector('section:has-text("Login")', { state: 'visible' });
+    await page.waitForSelector('section:has-text("Sign In")', { state: 'visible' });
     await page.waitForTimeout(1000); // Give time for storage to clear
 
     // Verify final storage state
@@ -138,7 +138,7 @@ test.describe.serial('User Authentication', () => {
     const url = process.env.LINGUA_QUIZ_URL || 'http://localhost:8080';
     await page.goto(`${url}/`);
     // Should see the login form when not authenticated
-    await expect(page.locator('section:has-text("Login")')).toBeVisible();
+    await expect(page.locator('section:has-text("Sign In")')).toBeVisible();
   });
 
   test('should handle server errors gracefully', async ({ page }) => {
@@ -148,7 +148,7 @@ test.describe.serial('User Authentication', () => {
         body: JSON.stringify({ message: 'Internal Server Error' }),
       });
     });
-    const loginSection = page.locator('section:has-text("Login")');
+    const loginSection = page.locator('section:has-text("Sign In")');
     await loginSection.locator('input[type="email"]').fill(testUser);
     await loginSection.locator('input[id="password"]').fill(testPassword);
     await loginSection.locator('button[type="submit"]').click();
@@ -173,15 +173,15 @@ test.describe.serial('User Authentication', () => {
     // Logout and wait for navigation
     await page.click('#login-logout-btn');
     // After logout, should see the login form
-    await page.waitForSelector('section:has-text("Login")', { state: 'visible' });
+    await page.waitForSelector('section:has-text("Sign In")', { state: 'visible' });
     await page.waitForTimeout(1000); // Ensure storage is cleared
 
     // Try to access protected route and verify redirect
     const url = process.env.LINGUA_QUIZ_URL || 'http://localhost:8080';
     await page.goto(`${url}/`);
     // After logout, should see the login form
-    await page.waitForSelector('section:has-text("Login")', { state: 'visible' });
-    await expect(page.locator('section:has-text("Login")')).toBeVisible();
+    await page.waitForSelector('section:has-text("Sign In")', { state: 'visible' });
+    await expect(page.locator('section:has-text("Sign In")')).toBeVisible();
   });
 
   test('should redirect to login when token is invalid', async ({ page }) => {
@@ -194,8 +194,8 @@ test.describe.serial('User Authentication', () => {
     const url = process.env.LINGUA_QUIZ_URL || 'http://localhost:8080';
     await page.goto(`${url}/`);
     // After logout, should see the login form
-    await page.waitForSelector('section:has-text("Login")', { state: 'visible' });
-    await expect(page.locator('section:has-text("Login")')).toBeVisible();
+    await page.waitForSelector('section:has-text("Sign In")', { state: 'visible' });
+    await expect(page.locator('section:has-text("Sign In")')).toBeVisible();
   });
 
   test('should redirect to login when token is expired', async ({ page }) => {
@@ -210,8 +210,8 @@ test.describe.serial('User Authentication', () => {
     const url = process.env.LINGUA_QUIZ_URL || 'http://localhost:8080';
     await page.goto(`${url}/`);
     // After logout, should see the login form
-    await page.waitForSelector('section:has-text("Login")', { state: 'visible' });
-    await expect(page.locator('section:has-text("Login")')).toBeVisible();
+    await page.waitForSelector('section:has-text("Sign In")', { state: 'visible' });
+    await expect(page.locator('section:has-text("Sign In")')).toBeVisible();
   });
 
   test('should redirect to login when token is missing', async ({ page }) => {
@@ -223,7 +223,7 @@ test.describe.serial('User Authentication', () => {
     const url = process.env.LINGUA_QUIZ_URL || 'http://localhost:8080';
     await page.goto(`${url}/`);
     // After logout, should see the login form
-    await page.waitForSelector('section:has-text("Login")', { state: 'visible' });
-    await expect(page.locator('section:has-text("Login")')).toBeVisible();
+    await page.waitForSelector('section:has-text("Sign In")', { state: 'visible' });
+    await expect(page.locator('section:has-text("Sign In")')).toBeVisible();
   });
 });

--- a/packages/e2e-tests/tests/helpers.js
+++ b/packages/e2e-tests/tests/helpers.js
@@ -28,17 +28,26 @@ async function register(page, email, password, success) {
     throw error;
   }
   
-  // Wait for the registration form to be visible
+  // First check if we're on login page and need to navigate to register
   try {
-    await page.waitForSelector('section:has-text("Register")', { state: 'visible', timeout: 2000 });
+    await page.waitForSelector('section:has-text("Sign In")', { state: 'visible', timeout: 2000 });
+    // Click on "Register here" link
+    await page.click('button:has-text("Register here")');
+    // Wait for register page to load
+    await page.waitForSelector('section:has-text("Create Account")', { state: 'visible', timeout: 2000 });
   } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error('Registration form not found. Page content:', await page.content().then(c => c.substring(0, 500)));
-    throw error;
+    // Check if we're already on register page
+    try {
+      await page.waitForSelector('section:has-text("Create Account")', { state: 'visible', timeout: 2000 });
+    } catch (error2) {
+      // eslint-disable-next-line no-console
+      console.error('Registration form not found. Page content:', await page.content().then(c => c.substring(0, 500)));
+      throw error2;
+    }
   }
   
   // Find the email and password inputs within the register section
-  const registerSection = page.locator('section:has-text("Register")');
+  const registerSection = page.locator('section:has-text("Create Account")');
   
   // Wait for inputs to be ready
   await registerSection.locator('input[type="email"]').waitFor({ state: 'visible', timeout: 5000 });
@@ -90,10 +99,10 @@ async function login(page, email, password) {
   }
   
   // Wait for the login form to be visible
-  await page.waitForSelector('section:has-text("Login")', { state: 'visible', timeout: 2000 });
+  await page.waitForSelector('section:has-text("Sign In")', { state: 'visible', timeout: 2000 });
   
   // Find the email and password inputs within the login section
-  const loginSection = page.locator('section:has-text("Login")');
+  const loginSection = page.locator('section:has-text("Sign In")');
   
   // Wait for inputs to be ready
   await loginSection.locator('input[type="email"]').waitFor({ state: 'visible', timeout: 5000 });
@@ -117,7 +126,7 @@ async function logout(page) {
   await page.waitForTimeout(500);
   await logoutButton.click();
   // After logout, we should see the login form
-  await expect(page.locator('section:has-text("Login")')).toBeVisible({ timeout: 5000 });
+  await expect(page.locator('section:has-text("Sign In")')).toBeVisible({ timeout: 5000 });
 }
 
 async function selectQuiz(page, quizName) {

--- a/packages/frontend/src/App.svelte
+++ b/packages/frontend/src/App.svelte
@@ -2,9 +2,11 @@
   import { onDestroy } from 'svelte';
   import { authStore, quizStore } from './stores.js';
   import Login from './views/Login.svelte';
+  import Register from './views/Register.svelte';
   import Quiz from './views/Quiz.svelte';
   
   let isAuthenticated = false;
+  let currentPage = 'login';
   
   authStore.subscribe(state => {
     isAuthenticated = state.isAuthenticated;
@@ -16,10 +18,18 @@
   onDestroy(() => {
     authStore.cleanup();
   });
+  
+  function handleNavigation(event) {
+    currentPage = event.detail.page;
+  }
 </script>
 
 {#if isAuthenticated}
   <Quiz />
 {:else}
-  <Login />
+  {#if currentPage === 'login'}
+    <Login on:navigate={handleNavigation} />
+  {:else if currentPage === 'register'}
+    <Register on:navigate={handleNavigation} />
+  {/if}
 {/if}

--- a/packages/frontend/src/views/Login.svelte
+++ b/packages/frontend/src/views/Login.svelte
@@ -1,30 +1,14 @@
 <script>
   import { authStore } from '../stores.js';
+  import { createEventDispatcher } from 'svelte';
+  
+  const dispatch = createEventDispatcher();
   
   let loginEmail = '';
   let loginPassword = '';
-  let registerEmail = '';
-  let registerPassword = '';
   let loginMessage = '';
-  let registerMessage = '';
   let showLoginPassword = false;
-  let showRegisterPassword = false;
   let isLoading = false;
-  
-  const passwordRequirements = [
-    { id: 'length', label: 'At least 8 characters long', test: pwd => pwd.length >= 8 },
-    { id: 'uppercase', label: 'Contains at least one uppercase letter', test: pwd => /[A-Z]/.test(pwd) },
-    { id: 'lowercase', label: 'Contains at least one lowercase letter', test: pwd => /[a-z]/.test(pwd) },
-    { id: 'number', label: 'Contains at least one number', test: pwd => /\d/.test(pwd) },
-    { id: 'special', label: 'Contains at least one special character', test: pwd => /[!@#$%^&*(),.?":{}|<>]/.test(pwd) }
-  ];
-  
-  $: passwordValidation = passwordRequirements.map(req => ({
-    ...req,
-    valid: req.test(registerPassword)
-  }));
-  
-  $: isPasswordValid = passwordValidation.every(req => req.valid);
   
   async function handleLogin(e) {
     e.preventDefault();
@@ -41,26 +25,8 @@
     }
   }
   
-  async function handleRegister(e) {
-    e.preventDefault();
-    if (!isPasswordValid) {
-      registerMessage = 'Please meet all password requirements';
-      return;
-    }
-    
-    isLoading = true;
-    registerMessage = '';
-    
-    try {
-      await authStore.register(registerEmail, registerPassword);
-      registerMessage = 'Registration successful. You can now log in.';
-      registerEmail = '';
-      registerPassword = '';
-    } catch (error) {
-      registerMessage = error.message;
-    } finally {
-      isLoading = false;
-    }
+  function navigateToRegister() {
+    dispatch('navigate', { page: 'register' });
   }
 </script>
 
@@ -73,7 +39,7 @@
   
   <div class="main-content login-content">
     <section class="sidebar-section">
-      <h2>Login</h2>
+      <h2>Sign In</h2>
       <form on:submit={handleLogin}>
         <div class="input-group">
           <input 
@@ -113,7 +79,7 @@
           </button>
         </div>
         <button type="submit" disabled={isLoading}>
-          <i class="fas fa-sign-in-alt"></i> Login
+          <i class="fas fa-sign-in-alt"></i> Sign In
         </button>
       </form>
       {#if loginMessage}
@@ -121,76 +87,37 @@
           {loginMessage}
         </p>
       {/if}
-    </section>
-
-    <section class="sidebar-section">
-      <h2>Register</h2>
-      <form on:submit={handleRegister}>
-        <div class="input-group">
-          <input 
-            type="email" 
-            bind:value={registerEmail} 
-            placeholder="Email" 
-            required 
-            disabled={isLoading}
-          />
-        </div>
-        <div class="input-group">
-          {#if showRegisterPassword}
-            <input 
-              type="text" 
-              bind:value={registerPassword} 
-              placeholder="Password" 
-              required 
-              disabled={isLoading}
-              id="register-password"
-            />
-          {:else}
-            <input 
-              type="password" 
-              bind:value={registerPassword} 
-              placeholder="Password" 
-              required 
-              disabled={isLoading}
-              id="register-password"
-            />
-          {/if}
-          <button 
-            type="button" 
-            class="toggle-password-btn"
-            on:click={() => showRegisterPassword = !showRegisterPassword}
-          >
-            <i class="fas fa-eye{showRegisterPassword ? '-slash' : ''}"></i>
-          </button>
-        </div>
-        
-        {#if registerPassword}
-          <div class="password-requirements">
-            <div class="password-requirements-title">Password Requirements:</div>
-            <div class="requirements-list">
-              {#each passwordValidation as req}
-                <div class="requirement {req.valid ? 'valid' : ''}">
-                  <span class="requirement-icon {req.valid ? 'valid' : ''}">
-                    {req.valid ? '✓' : '○'}
-                  </span>
-                  <span>{req.label}</span>
-                </div>
-              {/each}
-            </div>
-          </div>
-        {/if}
-        
-        <button type="submit" disabled={!isPasswordValid || isLoading}>
-          <i class="fas fa-user-plus"></i> Register
-        </button>
-      </form>
-      {#if registerMessage}
-        <p id="register-message" style:color={registerMessage.includes('successful') ? 'var(--success-color)' : 'var(--error-color)'}>
-          {registerMessage}
-        </p>
-      {/if}
+      
+      <div class="auth-link">
+        <p>Need an account? <button on:click={navigateToRegister} class="link-button">Register here</button></p>
+      </div>
     </section>
   </div>
   
   <div class="right-sidebar"></div>
 </main>
+
+<style>
+  .auth-link {
+    margin-top: 20px;
+    text-align: center;
+    color: var(--text-color);
+  }
+  
+  .link-button {
+    background: none;
+    border: none;
+    color: var(--primary-color);
+    text-decoration: underline;
+    cursor: pointer;
+    padding: 0;
+    margin: 0;
+    font-size: inherit;
+    width: auto;
+  }
+  
+  .link-button:hover {
+    color: var(--secondary-color);
+    background: none;
+  }
+</style>

--- a/packages/frontend/src/views/Register.svelte
+++ b/packages/frontend/src/views/Register.svelte
@@ -1,0 +1,166 @@
+<script>
+  import { authStore } from '../stores.js';
+  import { createEventDispatcher } from 'svelte';
+  
+  const dispatch = createEventDispatcher();
+  
+  let registerEmail = '';
+  let registerPassword = '';
+  let registerMessage = '';
+  let showRegisterPassword = false;
+  let isLoading = false;
+  
+  const passwordRequirements = [
+    { id: 'length', label: 'At least 8 characters long', test: pwd => pwd.length >= 8 },
+    { id: 'uppercase', label: 'Contains at least one uppercase letter', test: pwd => /[A-Z]/.test(pwd) },
+    { id: 'lowercase', label: 'Contains at least one lowercase letter', test: pwd => /[a-z]/.test(pwd) },
+    { id: 'number', label: 'Contains at least one number', test: pwd => /\d/.test(pwd) },
+    { id: 'special', label: 'Contains at least one special character', test: pwd => /[!@#$%^&*(),.?":{}|<>]/.test(pwd) }
+  ];
+  
+  $: passwordValidation = passwordRequirements.map(req => ({
+    ...req,
+    valid: req.test(registerPassword)
+  }));
+  
+  $: isPasswordValid = passwordValidation.every(req => req.valid);
+  
+  async function handleRegister(e) {
+    e.preventDefault();
+    if (!isPasswordValid) {
+      registerMessage = 'Please meet all password requirements';
+      return;
+    }
+    
+    isLoading = true;
+    registerMessage = '';
+    
+    try {
+      await authStore.register(registerEmail, registerPassword);
+      registerMessage = 'Registration successful. You can now log in.';
+      registerEmail = '';
+      registerPassword = '';
+      // Navigate back to login after successful registration
+      setTimeout(() => {
+        dispatch('navigate', { page: 'login' });
+      }, 2000);
+    } catch (error) {
+      registerMessage = error.message;
+    } finally {
+      isLoading = false;
+    }
+  }
+  
+  function navigateToLogin() {
+    dispatch('navigate', { page: 'login' });
+  }
+</script>
+
+<main class="container login-container">
+  <div class="left-sidebar">
+    <header>
+      <h1><i class="fas fa-language"></i> LinguaQuiz</h1>
+    </header>
+  </div>
+  
+  <div class="main-content login-content">
+    <section class="sidebar-section">
+      <h2>Create Account</h2>
+      <form on:submit={handleRegister}>
+        <div class="input-group">
+          <input 
+            type="email" 
+            bind:value={registerEmail} 
+            placeholder="Email" 
+            required 
+            disabled={isLoading}
+          />
+        </div>
+        <div class="input-group">
+          {#if showRegisterPassword}
+            <input 
+              type="text" 
+              bind:value={registerPassword} 
+              placeholder="Password" 
+              required 
+              disabled={isLoading}
+              id="register-password"
+            />
+          {:else}
+            <input 
+              type="password" 
+              bind:value={registerPassword} 
+              placeholder="Password" 
+              required 
+              disabled={isLoading}
+              id="register-password"
+            />
+          {/if}
+          <button 
+            type="button" 
+            class="toggle-password-btn"
+            on:click={() => showRegisterPassword = !showRegisterPassword}
+          >
+            <i class="fas fa-eye{showRegisterPassword ? '-slash' : ''}"></i>
+          </button>
+        </div>
+        
+        {#if registerPassword}
+          <div class="password-requirements">
+            <div class="password-requirements-title">Password Requirements:</div>
+            <div class="requirements-list">
+              {#each passwordValidation as req}
+                <div class="requirement {req.valid ? 'valid' : ''}">
+                  <span class="requirement-icon {req.valid ? 'valid' : ''}">
+                    {req.valid ? '✓' : '○'}
+                  </span>
+                  <span>{req.label}</span>
+                </div>
+              {/each}
+            </div>
+          </div>
+        {/if}
+        
+        <button type="submit" disabled={!isPasswordValid || isLoading}>
+          <i class="fas fa-user-plus"></i> Create Account
+        </button>
+      </form>
+      {#if registerMessage}
+        <p id="register-message" style:color={registerMessage.includes('successful') ? 'var(--success-color)' : 'var(--error-color)'}>
+          {registerMessage}
+        </p>
+      {/if}
+      
+      <div class="auth-link">
+        <p>Already have an account? <button on:click={navigateToLogin} class="link-button">Sign in here</button></p>
+      </div>
+    </section>
+  </div>
+  
+  <div class="right-sidebar"></div>
+</main>
+
+<style>
+  .auth-link {
+    margin-top: 20px;
+    text-align: center;
+    color: var(--text-color);
+  }
+  
+  .link-button {
+    background: none;
+    border: none;
+    color: var(--primary-color);
+    text-decoration: underline;
+    cursor: pointer;
+    padding: 0;
+    margin: 0;
+    font-size: inherit;
+    width: auto;
+  }
+  
+  .link-button:hover {
+    color: var(--secondary-color);
+    background: none;
+  }
+</style>


### PR DESCRIPTION
## Summary
- Split the combined login/register page into two separate, dedicated pages
- Improved user experience with clearer authentication flows

## Changes
- Created new `Register.svelte` component with dedicated registration form
- Refactored `Login.svelte` to only handle sign-in functionality
- Implemented navigation between Login and Register pages via event dispatching
- Updated `App.svelte` routing to support separate login/register pages
- Updated e2e tests to work with new separated authentication pages

## Test plan
- [ ] Manual testing: Navigate between login and register pages
- [ ] Manual testing: Successfully login with existing account
- [ ] Manual testing: Successfully register new account
- [ ] E2E tests pass for authentication flows
- [ ] No visual regressions in authentication UI

🤖 Generated with [Claude Code](https://claude.ai/code)