### PR TITLE
Add foldable/collapsible lists to learning progress section

### DIFF
--- a/packages/frontend/src/app.css
+++ b/packages/frontend/src/app.css
@@ -528,3 +528,51 @@ button:disabled {
     max-height: none;
   }
 }
+/* Foldable lists styles */
+.foldable-section {
+  margin-bottom: 15px;
+}
+
+.foldable-header {
+  cursor: pointer;
+  user-select: none;
+  display: flex;
+  align-items: center;
+  transition: background-color 0.2s ease;
+  padding: 5px;
+  margin: -5px;
+  border-radius: 4px;
+}
+
+.foldable-header:hover {
+  background-color: rgba(74, 144, 226, 0.1);
+}
+
+[data-theme="dark"] .foldable-header:hover {
+  background-color: rgba(91, 163, 245, 0.1);
+}
+
+.fold-icon {
+  font-size: 0.8em;
+  margin-right: 8px;
+  transition: transform 0.2s ease;
+  color: var(--text-color);
+  opacity: 0.6;
+}
+
+.foldable-content {
+  animation: fadeIn 0.3s ease;
+  margin-top: 10px;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+

--- a/packages/frontend/src/views/Quiz.svelte
+++ b/packages/frontend/src/views/Quiz.svelte
@@ -12,6 +12,32 @@
   let requestQueue = Promise.resolve();
   let currentRequestId = 0;
   
+  // Foldable lists state
+  let foldedLists = {
+    level0: false,
+    level1: false,
+    level2: false,
+    level3: false
+  };
+  
+  // Load saved fold states from localStorage
+  if (typeof window !== 'undefined') {
+    const savedFoldStates = localStorage.getItem('foldedLists');
+    if (savedFoldStates) {
+      try {
+        foldedLists = JSON.parse(savedFoldStates);
+      } catch (e) {
+        // Use defaults if parsing fails
+      }
+    }
+  }
+  
+  function toggleFold(level) {
+    foldedLists[level] = !foldedLists[level];
+    // Save to localStorage
+    localStorage.setItem('foldedLists', JSON.stringify(foldedLists));
+  }
+  
   // Reactive state from stores  
   $: wordSets = $quizStore.wordSets;
   $: selectedQuiz = $quizStore.selectedQuiz;
@@ -156,7 +182,7 @@
                 {loading ? 'Loading quizzes...' : '🎯 Select a quiz to start learning'}
               </option>
               {#each wordSets as set}
-                <option value={set.name}>{set.name} ({set.wordCount} {set.wordCount === 1 ? 'word' : 'words'})</option>
+                <option value={set.name}>{set.name}</option>
               {/each}
             </select>
           </div>
@@ -245,40 +271,60 @@
     <section class="sidebar-section learning-progress">
       <h2>Learning Progress</h2>
       
-      <div id="level-1">
-        <h3><i class="fas fa-tasks"></i> Learning ({level1Words.length})</h3>
-        <ol id="level-1-list">
-          {#each level1Words as word}
-            <li>{word}</li>
-          {/each}
-        </ol>
+      <div id="level-1" class="foldable-section">
+        <h3 class="foldable-header" on:click={() => toggleFold('level1')}>
+          <i class="fas fa-{foldedLists.level1 ? 'chevron-right' : 'chevron-down'} fold-icon"></i>
+          <i class="fas fa-tasks"></i> Learning ({level1Words.length})
+        </h3>
+        {#if !foldedLists.level1}
+          <ol id="level-1-list" class="foldable-content">
+            {#each level1Words as word}
+              <li>{word}</li>
+            {/each}
+          </ol>
+        {/if}
       </div>
       
-      <div id="level-2">
-        <h3><i class="fas fa-check-circle"></i> Translation Mastered (One Way) ({level2Words.length})</h3>
-        <ol id="level-2-list">
-          {#each level2Words as word}
-            <li>{word}</li>
-          {/each}
-        </ol>
+      <div id="level-2" class="foldable-section">
+        <h3 class="foldable-header" on:click={() => toggleFold('level2')}>
+          <i class="fas fa-{foldedLists.level2 ? 'chevron-right' : 'chevron-down'} fold-icon"></i>
+          <i class="fas fa-check-circle"></i> Translation Mastered One Way ({level2Words.length})
+        </h3>
+        {#if !foldedLists.level2}
+          <ol id="level-2-list" class="foldable-content">
+            {#each level2Words as word}
+              <li>{word}</li>
+            {/each}
+          </ol>
+        {/if}
       </div>
       
-      <div id="level-3">
-        <h3><i class="fas fa-check-circle"></i> Translation Mastered (Both Ways) ({level3Words.length})</h3>
-        <ol id="level-3-list">
-          {#each level3Words as word}
-            <li>{word}</li>
-          {/each}
-        </ol>
+      <div id="level-3" class="foldable-section">
+        <h3 class="foldable-header" on:click={() => toggleFold('level3')}>
+          <i class="fas fa-{foldedLists.level3 ? 'chevron-right' : 'chevron-down'} fold-icon"></i>
+          <i class="fas fa-check-circle"></i> Translation Mastered Both Ways ({level3Words.length})
+        </h3>
+        {#if !foldedLists.level3}
+          <ol id="level-3-list" class="foldable-content">
+            {#each level3Words as word}
+              <li>{word}</li>
+            {/each}
+          </ol>
+        {/if}
       </div>
       
-      <div id="level-0">
-        <h3><i class="fas fa-list"></i> New ({level0Words.length})</h3>
-        <ol id="level-0-list">
-          {#each level0Words as word}
-            <li>{word}</li>
-          {/each}
-        </ol>
+      <div id="level-0" class="foldable-section">
+        <h3 class="foldable-header" on:click={() => toggleFold('level0')}>
+          <i class="fas fa-{foldedLists.level0 ? 'chevron-right' : 'chevron-down'} fold-icon"></i>
+          <i class="fas fa-list"></i> New ({level0Words.length})
+        </h3>
+        {#if !foldedLists.level0}
+          <ol id="level-0-list" class="foldable-content">
+            {#each level0Words as word}
+              <li>{word}</li>
+            {/each}
+          </ol>
+        {/if}
       </div>
     </section>
   </div>


### PR DESCRIPTION
## Summary
This PR adds foldable/collapsible functionality to the learning progress lists in the Quiz component, improving the UI by allowing users to hide/show lists as needed.

## Changes
- ✨ Added collapsible functionality for all progress lists (New, Learning, Translation Mastered One/Both Ways)
- 🎨 Added chevron icons that rotate based on fold state
- 💾 Persist fold states in localStorage across page refreshes
- ✨ Added smooth fade-in animations when expanding lists
- 🎨 Added hover effects on foldable headers for better UX
- 🧹 Removed parentheses from "Translation Mastered (One Way)" and "Translation Mastered (Both Ways)" labels
- 🧹 Removed word count from quiz dropdown options for cleaner UI
- 🎨 Style improvements with proper dark mode support

## Test plan
1. Navigate to the Quiz page
2. Click on any list header to collapse/expand the list
3. Verify chevron icon rotates appropriately
4. Refresh the page and verify fold states are preserved
5. Test in both light and dark modes
6. Verify hover effects work on list headers

🤖 Generated with [Claude Code](https://claude.ai/code)