### PR TITLE
Migrate from Cloudflare to Let's Encrypt certificates

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -109,14 +109,14 @@ jobs:
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
+          username: nikolajer
           password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
       - uses: docker/build-push-action@v5
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.context }}/${{ matrix.dockerfile }}
           push: true
-          tags: ${{ secrets.DOCKER_REGISTRY_USERNAME }}/${{ matrix.image }}:${{ github.event.pull_request.head.sha || github.sha }},${{ secrets.DOCKER_REGISTRY_USERNAME }}/${{ matrix.image }}:latest
+          tags: nikolajer/${{ matrix.image }}:${{ github.event.pull_request.head.sha || github.sha }},nikolajer/${{ matrix.image }}:latest
 
   deploy:
     needs: [lint, unit-tests, integration-tests, build-images]
@@ -143,14 +143,9 @@ jobs:
           echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > $HOME/.kube/config
           chmod 600 $HOME/.kube/config
           
-      - name: Create TLS Secret
+      - name: Create namespace if not exists
         run: |
           kubectl create namespace $NAMESPACE --dry-run=client -o yaml | kubectl apply -f -
-          kubectl create secret tls lingua-quiz-tls \
-            --cert=<(echo "${{ secrets.SSL_CERT }}" | base64 -d) \
-            --key=<(echo "${{ secrets.SSL_KEY }}" | base64 -d) \
-            --namespace=$NAMESPACE \
-            --dry-run=client -o yaml | kubectl apply -f -
             
       - name: Deploy with Helm
         id: helm-deploy
@@ -167,9 +162,9 @@ jobs:
           helm upgrade --install lingua-quiz ./helm/lingua-quiz-app \
             --namespace $NAMESPACE \
             --set namespace=$NAMESPACE \
-            --set backend.image.repository=${{ secrets.DOCKER_REGISTRY_USERNAME }}/lingua-quiz-backend \
+            --set backend.image.repository=nikolajer/lingua-quiz-backend \
             --set backend.image.tag=$IMAGE_TAG \
-            --set frontend.image.repository=${{ secrets.DOCKER_REGISTRY_USERNAME }}/lingua-quiz-frontend \
+            --set frontend.image.repository=nikolajer/lingua-quiz-frontend \
             --set frontend.image.tag=$IMAGE_TAG \
             --set ingress.frontend.host=${{ github.ref == 'refs/heads/main' && 'lingua-quiz.nikolay-eremeev.com' || 'test-lingua-quiz.nikolay-eremeev.com' }} \
             --set secrets.jwtSecret="${{ secrets.JWT_SECRET }}" \

--- a/helm/lingua-quiz-app/values.yaml
+++ b/helm/lingua-quiz-app/values.yaml
@@ -83,11 +83,11 @@ postgres:
 # Ingress configuration for external access
 ingress:
   enabled: true
-  className: "" # Specify if you have a specific ingress class, e.g., "nginx"
+  className: "traefik" # Using Traefik ingress controller
   annotations:
-    {}
-    # kubernetes.io/ingress.class: nginx
-    # cert-manager.io/cluster-issuer: letsencrypt-prod # If using cert-manager
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    traefik.ingress.kubernetes.io/router.entrypoints: "websecure"
+    traefik.ingress.kubernetes.io/router.tls: "true"
   frontend:
     host: lingua-quiz.nikolay-eremeev.com # To be set by CI/env
   backend:


### PR DESCRIPTION
## Summary
Migrates lingua-quiz from manual Cloudflare certificate management to automated Let's Encrypt certificates via cert-manager.

## Changes
- ✅ Added cert-manager annotations for Let's Encrypt production issuer
- ✅ Configured Traefik ingress class and HTTPS routing  
- ✅ Removed manual TLS secret creation from CI/CD workflow
- ✅ Updated Docker registry references for consistency

## Benefits
- 🔒 Automated certificate renewal (no more manual cert updates)
- 🚀 Simplified deployment process
- 📋 Consistent with nikolay-eremeev-com setup
- ⚡ Zero-downtime certificate updates

## Testing
The deployment will automatically request and configure Let's Encrypt certificates. Cert-manager will handle the ACME challenge and certificate installation.

🤖 Generated with [Claude Code](https://claude.ai/code)