### PR TITLE
Add delete account functionality with multi-step browser confirmations

### DIFF
--- a/packages/frontend/src/stores.ts
+++ b/packages/frontend/src/stores.ts
@@ -192,6 +192,7 @@ interface QuizStore {
   submitAnswer: (token: string, answer: string) => Promise<any>;
   setLevel: (level: 'LEVEL_1' | 'LEVEL_2' | 'LEVEL_3' | 'LEVEL_4') => Promise<{ success: boolean; actualLevel: 'LEVEL_1' | 'LEVEL_2' | 'LEVEL_3' | 'LEVEL_4'; message?: string }>;
   reset: () => void;
+  saveAndCleanup: (token: string) => Promise<void>;
 }
 
 // Quiz Store with @linguaquiz/core integration


### PR DESCRIPTION
- Add delete account button to Quiz.svelte user interface
- Implement handleDeleteAccount function with two-step confirmation process
- Add red styling for delete button with theme-aware hover states
- Fix QuizStore interface to include saveAndCleanup method
- Ensure proper error handling and user feedback

🤖 Generated with [Claude Code](https://claude.ai/code)