### PR TITLE
Integrate backup functionality into main Helm chart

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -176,6 +176,7 @@ jobs:
             --set secrets.postgresUser="${{ secrets.POSTGRES_USER }}" \
             --set secrets.postgresPassword="${{ secrets.POSTGRES_PASSWORD }}" \
             --set secrets.googleCloudCredentialsB64="${{ secrets.GOOGLE_CLOUD_CREDENTIALS_B64 }}" \
+            ${{ github.ref == 'refs/heads/main' && '--set backup.enabled=true --set backup.spaces.accessKeyId="${{ secrets.SPACES_ACCESS_KEY_ID }}" --set backup.spaces.secretKey="${{ secrets.SPACES_SECRET_KEY }}"' || '--set backup.enabled=false' }} \
             --wait --timeout 5m
             
       - name: Check Migration Logs

--- a/helm/lingua-quiz-app/templates/backup-cronjob.yaml
+++ b/helm/lingua-quiz-app/templates/backup-cronjob.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "lingua-quiz-app.fullname" . }}-backup
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "lingua-quiz-app.namespace" . }}
   labels:
     {{- include "lingua-quiz-app.labels" . | nindent 4 }}
     app.kubernetes.io/component: backup
@@ -52,7 +52,7 @@ spec:
                       key: POSTGRES_PASSWORD
                 # Use the postgres service from this chart
                 - name: POSTGRES_HOST
-                  value: "{{ include "lingua-quiz-app.fullname" . }}-postgres"
+                  value: {{ include "lingua-quiz-app.postgresql.fullname" . }}
                 # Reference the spaces credentials secret
                 - name: SPACES_ACCESS_KEY_ID
                   valueFrom:

--- a/helm/lingua-quiz-app/values.yaml
+++ b/helm/lingua-quiz-app/values.yaml
@@ -139,7 +139,7 @@ migrations:
 
 # Database backup configuration
 backup:
-  enabled: false  # Enable/disable backup functionality
+  enabled: false  # Enable/disable backup functionality (enabled only for production via CI/CD)
   schedule: "0 2 * * *"  # Daily at 2 AM
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3


### PR DESCRIPTION
## Summary
- Fixed backup template bugs in Helm chart
- Integrated backup functionality into main lingua-quiz chart
- Configured backup to only run in production environment
- Added backup credentials to CI/CD pipeline from GitHub secrets

## Changes Made
1. **Fixed Helm template bugs**:
   - PostgreSQL host reference in `backup-cronjob.yaml:55`
   - Namespace reference in `backup-cronjob.yaml:6`

2. **Environment-specific backup**:
   - Backup enabled only for production (`main` branch)
   - Backup disabled for staging environments
   - Updated CI/CD pipeline to conditionally set backup flags

3. **Secrets integration**:
   - Added `SPACES_ACCESS_KEY_ID` and `SPACES_SECRET_KEY` to deployment
   - Backup credentials sourced from GitHub secrets

## Test plan
- [ ] Verify staging deployment has backup disabled
- [ ] Verify production deployment has backup enabled with correct credentials
- [ ] Test backup functionality in production
- [ ] Remove separate backup Helm release after successful integration

## Breaking Changes
- Backup is now disabled by default in values.yaml
- Production deployments now require `SPACES_ACCESS_KEY_ID` and `SPACES_SECRET_KEY` GitHub secrets

🤖 Generated with [Claude Code](https://claude.ai/code)